### PR TITLE
no return in void method

### DIFF
--- a/lexertl/parser/tokeniser/re_tokeniser_state.hpp
+++ b/lexertl/parser/tokeniser/re_tokeniser_state.hpp
@@ -76,7 +76,6 @@ struct basic_re_tokeniser_state
         _paren_count = rhs_._paren_count;
         _in_string = rhs_._in_string;
         _nl_id = rhs_._nl_id;
-        return this;
     }
 
     inline bool next(char_type &ch_)


### PR DESCRIPTION
When building with GCC 8:

```
/builddir/build/BUILD/php-pecl-parle-0.7.3/NTS/lib/lexertl14/lexertl/parser/tokeniser/re_tokeniser_state.hpp: Dans la fonction membre « void lexertl::detail::basic_re_tokeniser_state<ch_type, id_type>::assign(const lexertl::detail::basic_re_tokeniser_state<ch_type, id_type>&) »:
/builddir/build/BUILD/php-pecl-parle-0.7.3/NTS/lib/lexertl14/lexertl/parser/tokeniser/re_tokeniser_state.hpp:79:16: error: instruction « return » avec une valeur dans une fonction retournant « void » [-fpermissive]
         return this;
                ^~~~

```