### PR TITLE
Restore the ability to run tests with BUILD_TESTING and ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif ()
 
 if (BUILD_TESTING)
 	enable_testing()
-	add_subdirectory(test)
+	add_subdirectory(tests)
 endif()
 
 # Generate install

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Part of CMake configuration for lexertl library
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file licence_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+add_subdirectory(fail_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,3 +7,4 @@
 # file licence_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 add_subdirectory(fail_tests)
+add_subdirectory(include_test)

--- a/tests/include_test/CMakeLists.txt
+++ b/tests/include_test/CMakeLists.txt
@@ -1,0 +1,59 @@
+#
+# Part of CMake configuration for lexertl library
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file licence_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+include_directories(.)
+
+add_executable(lexertl_include_tests
+	# bitvector.cpp
+	blocks.cpp
+	charset.cpp
+	char_traits.cpp
+	debug.cpp
+	dot.cpp
+	end_node.cpp
+	enum_operator.cpp
+	enums.cpp
+	equivset.cpp
+	generate_cpp.cpp
+	generator.cpp
+	internals.cpp
+	iteration_node.cpp
+	iterator.cpp
+	leaf_node.cpp
+	lookup.cpp
+	match_results.cpp
+	memory_file.cpp
+	narrow.cpp
+	node.cpp
+	observer_ptr.cpp
+	parser.cpp
+	# ptr_list.cpp
+	# ptr_map.cpp
+	# ptr_stack.cpp
+	# ptr_vector.cpp
+	replace.cpp
+	re_token.cpp
+	re_tokeniser.cpp
+	re_tokeniser_helper.cpp
+	re_tokeniser_state.cpp
+	rules.cpp
+	runtime_error.cpp
+	scripts.cpp
+	selection_node.cpp
+	sequence_node.cpp
+	serialise.cpp
+	sm_to_csm.cpp
+	sm_traits.cpp
+	state_machine.cpp
+	stream_num.cpp
+	stream_shared_iterator.cpp
+	string_token.cpp
+	unicode.cpp
+	utf_iterators.cpp
+	main.cpp)
+target_link_libraries(lexertl_include_tests PRIVATE lexertl)


### PR DESCRIPTION
Before 7718de2511ecde6fa8794697cf20e22772810cc1 and c4bcaf805c9b5b2005dc3fdadf386a8f7c01711f, the easiest way to run the tests was to build with `-DBUILD_TESTING:BOOL=on` and invoking `ctest`.

Now, that option is broken because the `test/` subdirectory no longer exists:

https://github.com/BenHanson/lexertl14/blob/5bd3180ca1bd433157d503700e0329db11462923/CMakeLists.txt#L24-L27

The first commit makes it so that enabling `BUILD_TESTING` and invoking `ctest` compiles and runs what are now called the `fail_tests`, which seems to restore the previous status quo.

The second commit attempts to make the `include_test` directory work with CMake too. A test executable is built but not added to the tests executed with `ctest` (because compiling is the test). The commented-out source files are those that try to include headers that are not included in the repository.

~~The third and final commit makes `main()` return `0` in `include_test/main.cpp`. Since `main()` returns `int`, it should have an explicit `return` statement even though it isn’t intended to do anything useful.~~ (I have removed this commit; it turns out that the C++ standard makes a special exemption for `main` in “5.1.2.2.3 Program termination.”)

I’m happy to adjust the details or take a different approach in this PR, but it *would* be nice to be able to test the library via CMake again.