### PR TITLE
Quell g++12 null pointer error

### DIFF
--- a/include/lexertl/state_machine.hpp
+++ b/include/lexertl/state_machine.hpp
@@ -108,11 +108,14 @@ namespace lexertl
         void minimise_dfa(const id_type dfa_alphabet_,
             id_type_vector& dfa_, std::size_t size_) const
         {
+            id_type_vector lookup_(size_ / dfa_alphabet_, npos());
+            if(lookup_.empty()){
+                return;
+            }
             observer_ptr<const id_type> first_ = &dfa_.front();
             observer_ptr<const id_type> end_ = first_ + size_;
             id_type index_ = 1;
             id_type new_index_ = 1;
-            id_type_vector lookup_(size_ / dfa_alphabet_, npos());
             observer_ptr<id_type> lookup_ptr_ = &lookup_.front();
             index_set index_set_;
             const id_type bol_index_ = dfa_.front();


### PR DESCRIPTION
* Under g++12, there can be a warning for a null pointer dereference
* it requires to be compiling an optimized build:

In member function ‘void lexertl::basic_state_machine<char_type, id_ty>::minimise_dfa(id_type, id_type_vector&, std::size_t) const [with char_type = char; id_ty = short unsigned int]’,
    inlined from ‘void lexertl::basic_state_machine<char_type, id_ty>::minimise() [with char_type = char; id_ty = short unsigned int]’ at include/lexertl/state_machine.hpp:82:37:
include/lexertl/state_machine.hpp:120:26: warning: potential null pointer dereference [-Wnull-dereference]
  120 |             *lookup_ptr_ = 0;
      |             ~~~~~~~~~~~~~^~~

By making a check for an empty vector, this isn't raised.